### PR TITLE
Add keep_fresh option to @cached_as to prevent caching stale results on concurrent invalidation.

### DIFF
--- a/cacheops/invalidation.py
+++ b/cacheops/invalidation.py
@@ -23,6 +23,13 @@ def redis_can_unlink():
     return StrictVersion(redis_version) >= StrictVersion('4.0')
 
 
+def invalidate_key(cache_key):
+    if redis_can_unlink():
+        redis_client.execute_command('UNLINK', cache_key)
+    else:
+        redis_client.delete(cache_key)
+
+
 @queue_when_in_transaction
 @handle_connection_failure
 def invalidate_dict(model, obj_dict, using=DEFAULT_DB_ALIAS):

--- a/cacheops/invalidation.py
+++ b/cacheops/invalidation.py
@@ -23,11 +23,11 @@ def redis_can_unlink():
     return StrictVersion(redis_version) >= StrictVersion('4.0')
 
 
-def invalidate_key(cache_key):
+def invalidate_keys(*keys):
     if redis_can_unlink():
-        redis_client.execute_command('UNLINK', cache_key)
+        redis_client.execute_command('UNLINK', *keys)
     else:
-        redis_client.delete(cache_key)
+        redis_client.delete(*keys)
 
 
 @queue_when_in_transaction
@@ -70,10 +70,7 @@ def invalidate_model(model, using=DEFAULT_DB_ALIAS):
     if conjs_keys:
         cache_keys = redis_client.sunion(conjs_keys)
         keys = list(cache_keys) + conjs_keys
-        if redis_can_unlink():
-            redis_client.execute_command('UNLINK', *keys)
-        else:
-            redis_client.delete(*keys)
+        invalidate_keys(*keys)
     cache_invalidated.send(sender=model, obj_dict=None)
 
 

--- a/cacheops/query.py
+++ b/cacheops/query.py
@@ -123,7 +123,8 @@ def cached_as(*samples, **kwargs):
                     # the key to prevent falsely thinking the key was not
                     # invalidated when in fact it was invalidated and the
                     # function was called again in another process.
-                    precall_key = prefix + 'asp:' + key_func(func, args, kwargs, key_extra + [random()])
+                    suffix = key_func(func, args, kwargs, key_extra + [random()])
+                    precall_key = prefix + 'asp:' + suffix
                     for retry_count in range(max_retry_count):
                         # Retry calling the function until we get a valid
                         # result.

--- a/cacheops/query.py
+++ b/cacheops/query.py
@@ -2,10 +2,9 @@
 import sys
 import json
 import threading
-from random import random
-
 import six
 from six.moves import range
+from random import random
 from funcy import select_keys, cached_property, once, once_per, monkey, wraps, walk, chain
 from funcy.py3 import lmap, map, lcat, join_with
 from .cross import pickle, md5

--- a/cacheops/query.py
+++ b/cacheops/query.py
@@ -3,6 +3,7 @@ import sys
 import json
 import threading
 import six
+from six.moves import range
 from funcy import select_keys, cached_property, once, once_per, monkey, wraps, walk, chain
 from funcy.py3 import lmap, map, lcat, join_with
 from .cross import pickle, md5
@@ -21,7 +22,7 @@ from .utils import monkey_mix, stamp_fields, func_cache_key, cached_view_fab, fa
 from .sharding import get_prefix
 from .redis import redis_client, handle_connection_failure, load_script
 from .tree import dnfs
-from .invalidation import invalidate_obj, invalidate_dict, no_invalidation
+from .invalidation import invalidate_obj, invalidate_dict, no_invalidation, redis_can_unlink, invalidate_key
 from .transaction import transaction_states
 from .signals import cache_read
 
@@ -53,11 +54,19 @@ def cached_as(*samples, **kwargs):
     """
     Caches results of a function and invalidates them same way as given queryset(s).
     NOTE: Ignores queryset cached ops settings, always caches.
+
+    If retry_until_valid is True, this will retry calling this function up to
+    max_retry_count times until the given querysets are not invalidated during
+    the function call. This ensures that the result is in a consistent state and
+    prevents caching stale data. If the retry count is reached, a runtime error
+    is raised to prevent infinite looping.
     """
     timeout = kwargs.pop('timeout', None)
     extra = kwargs.pop('extra', None)
     key_func = kwargs.pop('key_func', func_cache_key)
     lock = kwargs.pop('lock', None)
+    retry_until_valid = kwargs.pop('retry_until_valid', False)
+    max_retry_count = kwargs.pop('max_retry_count', 10)
     if not samples:
         raise TypeError('Pass a queryset, a model or an object to cache like')
     if kwargs:
@@ -97,16 +106,45 @@ def cached_as(*samples, **kwargs):
                 return func(*args, **kwargs)
 
             prefix = get_prefix(func=func, _cond_dnfs=cond_dnfs, dbs=dbs)
-            cache_key = prefix + 'as:' + key_func(func, args, kwargs, key_extra)
+            key_suffix = key_func(func, args, kwargs, key_extra)
+            cache_key = prefix + 'as:' + key_suffix
 
             with redis_client.getting(cache_key, lock=lock) as cache_data:
                 cache_read.send(sender=None, func=func, hit=cache_data is not None)
                 if cache_data is not None:
                     return pickle.loads(cache_data)
-                else:
+                elif not retry_until_valid:
                     result = func(*args, **kwargs)
                     cache_thing(prefix, cache_key, result, cond_dnfs, timeout, dbs=dbs)
                     return result
+                else:
+                    # We call this "asp" for "as precall" because this key is
+                    # cached before the actual function is called.
+                    precall_key = prefix + 'asp:' + key_suffix
+                    for retry_count in range(max_retry_count):
+                        # Retry calling the function until we get a valid
+                        # result.
+                        #
+                        # Cache a precall_key to watch for invalidation during
+                        # the function call. Its value does not matter. If and
+                        # only if it remains valid before, during, and after the
+                        # call, the result can be cached and returned.
+                        cache_thing(prefix, precall_key, True, cond_dnfs, timeout, dbs=dbs)
+
+                        result = func(*args, **kwargs)
+                        if redis_client.get(precall_key) is None:
+                            # Key was invalidated while calling function. Retry.
+                            continue
+
+                        cache_thing(prefix, cache_key, result, cond_dnfs, timeout, dbs=dbs)
+                        if redis_client.get(precall_key) is None:
+                            # Key was invalidated while caching. Retry.
+                            invalidate_key(cache_key)
+                            continue
+
+                        return result
+
+                    raise RuntimeError('Too many retries, aborting.')
 
         return wrapper
     return decorator

--- a/cacheops/query.py
+++ b/cacheops/query.py
@@ -100,8 +100,6 @@ def cached_as(*samples, **kwargs):
     if lock is None:
         lock = any(qs._cacheprofile['lock'] for qs in querysets)
 
-    cached_as.nonce = 0
-
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):

--- a/cacheops/query.py
+++ b/cacheops/query.py
@@ -23,7 +23,7 @@ from .utils import monkey_mix, stamp_fields, func_cache_key, cached_view_fab, fa
 from .sharding import get_prefix
 from .redis import redis_client, handle_connection_failure, load_script
 from .tree import dnfs
-from .invalidation import invalidate_obj, invalidate_dict, no_invalidation, redis_can_unlink, invalidate_key
+from .invalidation import invalidate_obj, invalidate_dict, no_invalidation, invalidate_keys
 from .transaction import transaction_states
 from .signals import cache_read
 
@@ -144,7 +144,7 @@ def cached_as(*samples, **kwargs):
                         cache_thing(prefix, cache_key, result, cond_dnfs, timeout, dbs=dbs)
                         if redis_client.get(precall_key) is None:
                             # Key was invalidated while caching. Retry.
-                            invalidate_key(cache_key)
+                            invalidate_keys(cache_key)
                             continue
 
                         return result

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -75,7 +75,7 @@ else:
             # Make in memory sqlite test db to work with threads
             # See https://code.djangoproject.com/ticket/12118
             'TEST': {
-                'NAME': 'file:cacheops_sqlite.db?mode=memory&cache=shared'
+                'NAME': ':memory:cache=shared'
             }
         },
         'slave': {

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -75,7 +75,7 @@ else:
             # Make in memory sqlite test db to work with threads
             # See https://code.djangoproject.com/ticket/12118
             'TEST': {
-                'NAME': '/dev/shm/cacheops_sqlite.db'
+                'NAME': 'file:cacheops_sqlite.db?mode=memory&cache=shared'
             }
         },
         'slave': {

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -262,7 +262,7 @@ class DecoratorTests(BaseTestCase):
         p.save()                               # invalidate by Post
         self.assertEqual(get_calls(1), 3)      # miss and cache
 
-    def test_cached_as_retries_if_invalidated_during_func(self):
+    def test_cached_as_not_cached_if_invalidated_during_func(self):
         c = Category.objects.create(title='test')
         get_calls = make_invalidate_and_inc(cached_as(c, keep_fresh=True), c, 1)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 
-from cacheops import invalidate_all
+from cacheops import invalidate_all, invalidate_obj
 from cacheops.transaction import transaction_states
 
 
@@ -29,6 +29,20 @@ def make_inc(deco=lambda x: x):
 
     inc.get = lambda: calls[0]
     return inc
+
+
+def make_invalidate_and_inc(deco, obj, invalidation_count):
+    calls = [0]
+
+    @deco
+    def invalidate_and_inc(_=None, **kw):
+        if calls[0] < invalidation_count:
+            invalidate_obj(obj)
+        calls[0] += 1
+        return calls[0]
+
+    invalidate_and_inc.get = lambda: calls[0]
+    return invalidate_and_inc
 
 
 # Thread utilities


### PR DESCRIPTION
This change allows us to ensure that a @cached_as function always returns valid results and that stale data is not cached. Without this change, there are at least two possible race conditions:

### Case 1: Caching stale data

Consider a function `get_book_names()` decorated with `@cached_as(Book.objects.all())`. This function executes the queryset `Book.objects.all()` to return an array of book names. The cache needs to be invalidated if any book changes.

1. Process 1 calls `get_book_names()`. Its return value is not yet cached so Process 1 begins evaluating the function `get_book_names()` and executes the query to get all books.
2. Process 2 modifies an book `b` and changes its name from "Stale" to "New" and saves it.
3. All cache keys that depend on `b` are invalidated.
4. Process 1 finishes evaluating `get_book_names()`. This list of book names still has the name "Stale" for book `b`. This list is now cached.
5. Calling `f()` again returns the cached value with stale data.

In this case, the stale data should not be cached so that future requests will get the correct book names. It would be even better if this function call returned the new book names.

### Case 2: Returning inconsistent data

Consider a function `get_book_author_names()` decorated with `@cached_as(Book, Author)`. This function executes the queryset to return an array of books and their authors. The cache needs to be invalidated if any book or author changes.

1. Process 1 calls `get_book_author_names()`. Its return value is not yet cached so Process 1 begins evaluating the function `get_book_author_names()` and executes the query to get all books. Process 1 iterates through each book and for each book executes a separate query to get its author. Suppose there are 10 books by author "Sue". Process 1 iterates through the first five books by Sue to get the book and author names.
2. Process 2 modifies the author "Sue" and changes her name from "Sue" to "Susan" and saves it.
3. All cache keys that depend on Sue are invalidated.
4. Process 1 iterates through the remaining five books by Sue. These books now have author name "Susan". The resulting list of books now has five books by Sue and five by Susan, which is inconsistent.

This problem could be fixed by getting all books and authors in a single SQL query or by wrapping the entire call in a transaction, but the fix for Case 1 also addresses Case 2.

### The fix

We would like to enforce the invariant that if the samples that the function depends on are invalidated, that the function's return value is also invalid. To enforce this condition, we do the following:
* Before calling the function, we store a precache key unique to this function invocation that will get invalidated whenever the samples are invalidated.
* Before returning a value, check to see if the precache key is still present. If not, store the precache key again and retry calling the function.
* After caching the result, check to see if the precache key is still present. If not, invalidate the cached result and retry calling the function.

Note that if your function does any internal caching, this will need to be reset when the function is invoked to prevent stale data from persisting across retries. (e.g. call `copy.deepcopy()` on QuerySets to clear the result cache).

I added a `max_retry_count` parameter to help prevent infinite loops. I decided to raise an exception when the retry count is reached to ensure that invalid data is never returned. If it is acceptable to stale data you could change this behavior.

#### Automated tests
I added two automated tests:
1. `test_cached_as_retries_if_invalidated_during_func`
2. `test_cached_as_raises_exception_if_too_many_retries`

#### Manual tests
I ran the pasturemap-api app using this branch of cacheops and verified the following that if two concurrent worker processes 